### PR TITLE
Add 1 minute auto-silence preference to the alarm clock

### DIFF
--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -76,6 +76,7 @@
     <string name="auto_silence_never" msgid="4302257878142130807">"Off"</string>
   <string-array name="auto_silence_entries">
     <item msgid="7718972982871612080">"Off"</item>
+    <item msgid="1012951710292171615">"1 minute"</item>
     <item msgid="5431906692406316549">"5 minutes"</item>
     <item msgid="7742728812068919959">"10 minutes"</item>
     <item msgid="2855948657259647629">"15 minutes"</item>


### PR DESCRIPTION
Would be really nice to have an auto-off period of one minute if possible.
